### PR TITLE
Count requested_reviews

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+nohup.out
+output.json

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ sudo apt install libsox-fmt-mp3
 - cd Review-Reminder
 - vi review_requested.sh
 set your favorable time in REQUEST_TIME_ARRAY
+- Before running the script you've to set two variables:
+    - USERNAME i.e your github username
+    - GIT_ACCESS_TOKEN i.e your personal access token for GitHub on the commandline
 - run bash file using `nohup` as:
 ```sh
 nohup bash review_requested.sh &

--- a/review_requested.sh
+++ b/review_requested.sh
@@ -12,11 +12,11 @@ do
 		count=`cat output.json`
 		if [[ $count -gt 1 ]]
 		then
-				notify-send "Hurray! Review Time. You've ${count} review requests."
+				notify-send "Hurray! It's review time. You've ${count} review requests."
 				play attention-sound.mp3
 				google-chrome https://github.com/pulls/review-requested --new-window
 		else
-				notify-send "Cheers! No reviews requested"
+				notify-send "Cheers! You have 0 review request."
 		fi
 	fi
 done

--- a/review_requested.sh
+++ b/review_requested.sh
@@ -1,15 +1,22 @@
 #!/bin/bash
 
 declare -a REQUEST_TIME_ARRAY
-REQUEST_TIME_ARRAY=(103000 163000 232150)
+REQUEST_TIME_ARRAY=(103000 163000)
 while true 
 do
 	now=$(date +"%H%M%S")
 	sleep 0.5
 	if [[ " ${REQUEST_TIME_ARRAY[@]} " =~ " $now " ]]
 	then
-		notify-send "Hurray! Review Time"
-		play attention-sound.mp3
-		google-chrome https://github.com/pulls/review-requested --new-window
+		curl -u kiranparajuli589:00f3699c8f17539ce7c4af2a79603de6c4996b4a https://api.github.com/search/issues\?q\=is:pr+state:open+review-requested:kiranparajuli589+archived:false | jq ".total_count" > output.json
+		count=`cat output.json`
+		if [[ $count -gt 1 ]]
+		then
+				notify-send "Hurray! Review Time. You've ${count} review requests."
+				play attention-sound.mp3
+				google-chrome https://github.com/pulls/review-requested --new-window
+		else
+				notify-send "Cheers! No reviews requested"
+		fi
 	fi
 done

--- a/review_requested.sh
+++ b/review_requested.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+echo "This is user ${USERNAME} with token ${GIT_ACCESS_TOKEN}"
 declare -a REQUEST_TIME_ARRAY
 REQUEST_TIME_ARRAY=(103000 163000)
 while true 
@@ -8,7 +8,7 @@ do
 	sleep 0.5
 	if [[ " ${REQUEST_TIME_ARRAY[@]} " =~ " $now " ]]
 	then
-		curl -u kiranparajuli589:00f3699c8f17539ce7c4af2a79603de6c4996b4a https://api.github.com/search/issues\?q\=is:pr+state:open+review-requested:kiranparajuli589+archived:false | jq ".total_count" > output.json
+		curl -u $USERNAME:$GIT_ACCESS_TOKEN https://api.github.com/search/issues\?q\=is:pr+state:open+review-requested:${USERNAME}+archived:false | jq ".total_count" > output.json
 		count=`cat output.json`
 		if [[ $count -gt 1 ]]
 		then


### PR DESCRIPTION
Fixes #1 
With this PR:
:heavy_check_mark: use of GitHub API
:heavy_check_mark: count requested reviews
:heavy_check_mark: only open chrome if the count is greater than 1
:heavy_check_mark: notify user according to the count
:heavy_check_mark: use variables for USERNAME & GIT_ACCESS_TOKEN